### PR TITLE
Makeshift tokens collection and iterator

### DIFF
--- a/token/src/lib.rs
+++ b/token/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod token;
+pub mod token_collection;
 pub mod token_type;

--- a/token/src/token_collection.rs
+++ b/token/src/token_collection.rs
@@ -1,0 +1,46 @@
+pub struct TokenCollection {
+    tokens: Vec<i32>,
+}
+
+impl TokenCollection {
+    pub fn new() -> Self {
+        Self {
+            tokens: vec![234, 78, 235],
+        }
+    }
+
+    pub fn iter(&self) -> TokenIterator {
+        TokenIterator {
+            index: 0,
+            token_collection: self,
+        }
+    }
+}
+
+pub struct TokenIterator<'a> {
+    index: usize,
+    token_collection: &'a TokenCollection,
+}
+
+impl Iterator for TokenIterator<'_> {
+    type Item = i32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.token_collection.tokens.len() {
+            let token = self.token_collection.tokens.get(self.index);
+            self.index += 1;
+            return token.copied();
+        }
+
+        None
+    }
+}
+
+#[test]
+fn test() {
+    let tc = TokenCollection::new();
+    let mut iter = tc.iter().peekable();
+    println!("{:#?}", &iter.peek());
+    println!("{:#?}", &iter.next());
+    println!("{:#?}", &iter.peek());
+}


### PR DESCRIPTION
A potential enhancement to creating the parser could be to make a token collection and iterator. The scanner would produce a `TokenCollection` which contains a array or vector of tokens allowing a call to `.iter()` removing the need for custom `next` and `peek` functions in the parser.

- [ ] Make token collection store tokens not i32s

Resources: https://refactoring.guru/design-patterns/iterator/rust/example#example-1

Here is a quick example of its usage:
```rust
#[test]
fn test() {
    let tc = TokenCollection::new();
    let mut iter = tc.iter().peekable();
    println!("{:#?}", &iter.peek());
    println!("{:#?}", &iter.next());
    println!("{:#?}", &iter.peek());
}
```