### PR TITLE
Cli fix - minor

### DIFF
--- a/jtools/src/main.rs
+++ b/jtools/src/main.rs
@@ -1,4 +1,4 @@
-use std::io::{stdout, Error, Write};
+use std::io::{stderr, stdout, Error, Write};
 
 use cli::Cli;
 
@@ -6,6 +6,6 @@ fn main() -> Result<(), Error> {
     match Cli.run() {
         Ok(None) => Ok(()),
         Ok(Some(data)) => writeln!(stdout(), "{}", data),
-        Err(error) => writeln!(stdout(), "{}", error),
+        Err(error) => writeln!(stderr(), "{}", error),
     }
 }


### PR DESCRIPTION
Print errors to stderr and not stdout this prevents errors being written to files etc..

Take the following example where an error is written to stdout and then redirected to a new file data.json. The file will then contain the error message, which is not wanted behaviour. Simply changing `stdout` to `stderr` prevents this.

```
jtools format -p stdin '[1, 2, ]' > data.json
```