### PR TITLE
Updated parser error messages

### DIFF
--- a/parser/src/parser_error.rs
+++ b/parser/src/parser_error.rs
@@ -2,8 +2,8 @@ use std::fmt::Display;
 
 #[derive(Debug, PartialEq)]
 pub enum ParserError {
-    DuplicateProperty { error: String },
-    UnexpectedToken { error: String },
+    DuplicateProperty { property: String, error: String },
+    UnexpectedToken { header: String, error: String },
 }
 
 impl std::error::Error for ParserError {}
@@ -11,8 +11,12 @@ impl std::error::Error for ParserError {}
 impl Display for ParserError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ParserError::DuplicateProperty { error } => write!(f, "Duplicate Property {}", error),
-            ParserError::UnexpectedToken { error } => write!(f, "Unexpected Token {}", error),
+            ParserError::DuplicateProperty { property, error } => {
+                write!(f, "Duplicate Property {} {}", property, error)
+            }
+            ParserError::UnexpectedToken { header, error } => {
+                write!(f, "{} {}", header, error)
+            }
         }
     }
 }
@@ -24,8 +28,9 @@ mod parser_error_tests {
     #[test]
     fn duplicate_property_message() {
         assert_eq!(
-            "Duplicate Property some error",
+            "Duplicate Property  some error",
             ParserError::DuplicateProperty {
+                property: "".to_string(),
                 error: "some error".to_string()
             }
             .to_string()
@@ -35,9 +40,10 @@ mod parser_error_tests {
     #[test]
     fn unexpected_token_message() {
         assert_eq!(
-            "Unexpected Token ",
+            "Header error",
             ParserError::UnexpectedToken {
-                error: "".to_string()
+                header: "Header".to_string(),
+                error: "error".to_string()
             }
             .to_string()
         );


### PR DESCRIPTION
Improve the parser errors so they include more meaning full descriptions

This also moves consuming both [ and { to parse literal function