### PR TITLE
Print errors to stdout by default

### DIFF
--- a/cli/src/cli_args.rs
+++ b/cli/src/cli_args.rs
@@ -18,34 +18,37 @@ pub enum Input {
 
 #[derive(Subcommand, Debug, PartialEq)]
 pub enum Command {
+    /// Parse an input
     Parse {
         /// Return bool if parsing was successful or not
         #[arg(short, long, default_value_t = false)]
         verify: bool,
 
-        /// Write input to stdin if successful
+        /// Prevent writing input to stdin if successful
         #[arg(short, long, default_value_t = false)]
-        write: bool,
+        prevent_write: bool,
 
         #[command(subcommand)]
         input: Input,
     },
+    /// Format an input
     Format {
         /// Specifiy the number of spaces (0-8) to apply to the input. Default=4
         #[arg(short, long, value_parser = value_parser!(u8).range(0..=8))]
         spacing: Option<u8>,
 
-        /// Write formatted input to stdin if successful
+        /// Prevent writing input to stdin if successful
         #[arg(short, long, default_value_t = false)]
-        write: bool,
+        prevent_write: bool,
 
         #[command(subcommand)]
         input: Input,
     },
+    /// Minify an input
     Minify {
-        /// Write minified input to stdin if successful
+        /// Prevent writing input to stdin if successful
         #[arg(short, long, default_value_t = false)]
-        write: bool,
+        prevent_write: bool,
 
         #[command(subcommand)]
         input: Input,
@@ -68,7 +71,7 @@ mod cli_args_tests {
             CliArgs {
                 command: Command::Format {
                     spacing: Some(8),
-                    write: false,
+                    prevent_write: false,
                     input: Input::File {
                         prevent_override: false,
                         path: PathBuf::from("data.json")
@@ -85,14 +88,14 @@ mod cli_args_tests {
             CliArgs {
                 command: Command::Parse {
                     verify: true,
-                    write: true,
+                    prevent_write: true,
                     input: Input::File {
                         prevent_override: true,
                         path: PathBuf::from("data.json")
                     }
                 }
             },
-            CliArgs::parse_from(&["", "parse", "-w", "-v", "file", "-p", "data.json"])
+            CliArgs::parse_from(&["", "parse", "-p", "-v", "file", "-p", "data.json"])
         )
     }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -27,7 +27,7 @@ impl Cli {
         match command {
             Command::Parse {
                 verify,
-                write,
+                prevent_write,
                 input,
             } => {
                 let source = self.source(&input)?;
@@ -37,20 +37,20 @@ impl Cli {
 
                 let parser = Parser::new(&source, tokens);
 
-                if verify && write {
+                if verify && !prevent_write {
                     return Ok(parser.is_valid().to_string());
                 }
 
                 parser.parse()?;
 
-                if write {
-                    return Ok(source.to_string());
+                if prevent_write {
+                    return Ok("Parse successful".to_string());
                 }
 
-                Ok("Parse successful".to_string())
+                Ok(source.to_string())
             }
             Command::Format {
-                write,
+                prevent_write,
                 spacing,
                 input,
             } => {
@@ -71,13 +71,16 @@ impl Cli {
 
                 self.is_file_then_override(&input, &json)?;
 
-                if write {
-                    return Ok(json);
+                if prevent_write {
+                    return Ok("Format successful".to_string());
                 }
 
-                Ok("Format successful".to_string())
+                Ok(json)
             }
-            Command::Minify { write, input } => {
+            Command::Minify {
+                prevent_write,
+                input,
+            } => {
                 let source = self.source(&input)?;
 
                 let mut scanner = Scanner::new(&source);
@@ -91,11 +94,11 @@ impl Cli {
 
                 self.is_file_then_override(&input, &json)?;
 
-                if write {
-                    return Ok(json);
+                if prevent_write {
+                    return Ok("Minify successful".to_string());
                 }
 
-                Ok("Minify successful".to_string())
+                Ok(json)
             }
         }
     }


### PR DESCRIPTION
Create better cli defaults. Printing to stdout is more useful as a default. Change the write to prevent_write so users do not have to have the output displayed.