### PR TITLE
Release optimisations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
 resolver = "2"
 members = [ "ast", "benches", "cli", "error_preview", "format", "jtools" , "parser", "scanner", "tests", "token"]
+
+[profile.release]
+strip = true
+opt-level = "s"
+lto = true
+codgen-units = 1

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Unterminated string
 - Handwritten scanner/lexical analyser
 ---
 
+## Installation
+
+1) Download a compatible binary from the [jtools GitHub releases page](https://github.com/AlexanderWatts/jtools/releases "jtools GitHub releases page")
+2) Extract and move the `jtools` binary to a directory included in your `$PATH`
+    - On macOS, for example, you can move it to `/usr/local/bin`
+
 ## Usage
 
 To see all available commands run:


### PR DESCRIPTION
Optimisations for reducing binary size when doing cargo/cross build. These optimisations reduce the binary size from 1.1MB to 662k
