### PR TITLE
Workspace defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "ast"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "token",
 ]
@@ -92,7 +92,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "benches"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "ast",
  "criterion",
@@ -216,7 +216,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cli"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "ast",
  "clap 4.5.23",
@@ -307,14 +307,14 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "error_preview"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "unicode-width",
 ]
 
 [[package]]
 name = "format"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "ast",
 ]
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "jtools"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "cli",
 ]
@@ -451,7 +451,7 @@ checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "parser"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "ast",
  "error_preview",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "scanner"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "error_preview",
  "token",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "ast",
  "format",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "token"
-version = "0.1.0"
+version = "1.0.0"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,24 @@
 [workspace]
 resolver = "2"
-members = [ "ast", "benches", "cli", "error_preview", "format", "jtools" , "parser", "scanner", "tests", "token"]
+members = [
+	"ast",
+	"benches",
+	"cli",
+	"error_preview",
+	"format",
+	"jtools",
+	"parser",
+	"scanner",
+	"tests",
+	"token"
+]
+
+[workspace.package]
+version = "1.0.0"
+edition = "2021"
+authors = ["Alex Watts <acwatts.dev@gmail.com>"]
+repository = "https://github.com/AlexanderWatts/jtools"
+license = "MIT"
 
 [profile.release]
 strip = true

--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ Output:
 Usage: jtools <COMMAND>
 
 Commands:
-  parse
-  format
-  minify
+  parse   Parse
+  format  Format
+  minify  Minify
   help    Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help  Print help
-
+  -h, --help     Print help
+  -V, --version  Print version
 ```
 
 ### Examples

--- a/ast/Cargo.toml
+++ b/ast/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "ast"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 token = { path = "../token" }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "benches"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 token = { path = "../token" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "cli"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 clap = { version = "4.5.23", features = ["derive"] }

--- a/cli/src/cli_args.rs
+++ b/cli/src/cli_args.rs
@@ -56,6 +56,7 @@ pub enum Command {
 }
 
 #[derive(Parser, Debug, PartialEq)]
+#[command(name = "jtools", version)]
 pub struct CliArgs {
     #[command(subcommand)]
     pub command: Command,

--- a/error_preview/Cargo.toml
+++ b/error_preview/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "error_preview"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 unicode-width = "0.2.0"

--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "format"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 ast = { path = "../ast" }

--- a/jtools/Cargo.toml
+++ b/jtools/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "jtools"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 cli = { path = "../cli" }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "parser"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 ast = { path = "../ast" }

--- a/scanner/Cargo.toml
+++ b/scanner/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "scanner"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 token = { path = "../token" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "tests"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 token = { path = "../token" }

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "token"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true


### PR DESCRIPTION
Maintain info like authors and version in the workspace instead of each crate. The `version` is especially important when dealing with releases which allows `clap` to use this `semver` as an output to the user


https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table